### PR TITLE
test: add integration test for extension function usage

### DIFF
--- a/test-integration/src/test/kotlin/community/flock/kmapper/KMapperTest.kt
+++ b/test-integration/src/test/kotlin/community/flock/kmapper/KMapperTest.kt
@@ -700,6 +700,38 @@ class KMapperTest {
     }
 
     @Test
+    fun shouldCompile_extensionFunction() {
+        IntegrationTest(options)
+            .file("App.kt") {
+                $$"""
+                |package sample
+                |
+                |import community.flock.kmapper.mapper
+                |
+                |data class User(val firstName: String, val lastName: String, val age: Int)
+                |data class UserDto(val name: String, val age: Int)
+                |
+                |fun User.toDto(): UserDto = mapper {
+                |    name = "${it.firstName} ${it.lastName}"
+                |}
+                |
+                |fun main() {
+                |  val user = User("John", "Doe", 99)
+                |  val userDto = user.toDto()
+                |  println(userDto)
+                |}
+                |
+                """.trimMargin()
+            }
+            .compileSuccess { output ->
+                assertTrue(
+                    output.contains("UserDto(name=John Doe, age=99)"),
+                    "Expected UserDto(name=John Doe, age=99) in output"
+                )
+            }
+    }
+
+    @Test
     fun shouldSuccess_ignoreValue() {
         IntegrationTest(options)
             .file("App.kt") {


### PR DESCRIPTION
## Summary
- Adds integration test verifying that `mapper` works inside extension functions
- Tests the pattern: `fun User.toDto(): UserDto = mapper { name = "${it.firstName} ${it.lastName}" }`
- Confirms auto-mapping of same-name/type fields (e.g. `age`) works in this context

## Test plan
- [x] New test `shouldCompile_extensionFunction` passes
- [x] All existing integration tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)