### PR TITLE
Fix field resolution for binary dependency types

### DIFF
--- a/compiler-plugin/src/main/kotlin/community/flock/kmapper/compiler/fir/KMapperFirMappingChecker.kt
+++ b/compiler-plugin/src/main/kotlin/community/flock/kmapper/compiler/fir/KMapperFirMappingChecker.kt
@@ -5,6 +5,7 @@ import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.diagnostics.reportOn
+import org.jetbrains.kotlin.fir.FirBinaryDependenciesModuleData
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
@@ -136,6 +137,7 @@ class KMapperFirMappingChecker(val collector: MessageCollector, private val sess
 
     private fun ConeKotlinType.resolveConstructorFields(): List<Field> {
         val classSymbol = toRegularClassSymbol(session)
+        if (classSymbol?.moduleData is FirBinaryDependenciesModuleData) return emptyList()
         val primaryConstructor = classSymbol?.constructors(session)?.firstOrNull()
         return primaryConstructor?.valueParameterSymbols?.map { parameter ->
             Field(
@@ -154,6 +156,7 @@ class KMapperFirMappingChecker(val collector: MessageCollector, private val sess
 
     private fun ConeKotlinType.resolvePropertyFields(): List<Field> {
         val classSymbol = toRegularClassSymbol(session)
+        if (classSymbol?.moduleData is FirBinaryDependenciesModuleData) return emptyList()
         return classSymbol?.declaredProperties(session)
             .orEmpty()
             .map { property ->

--- a/compiler-plugin/src/main/kotlin/community/flock/kmapper/compiler/fir/KmapperFirLogic.kt
+++ b/compiler-plugin/src/main/kotlin/community/flock/kmapper/compiler/fir/KmapperFirLogic.kt
@@ -2,6 +2,7 @@ package community.flock.kmapper.compiler.fir
 
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.FirBinaryDependenciesModuleData
 import org.jetbrains.kotlin.fir.declarations.DirectDeclarationsAccess
 import org.jetbrains.kotlin.fir.declarations.FirEnumEntry
 import org.jetbrains.kotlin.fir.declarations.constructors
@@ -146,6 +147,7 @@ private fun ConeKotlinType.listElementType(): ConeKotlinType? {
 context(session: FirSession)
 private fun ConeKotlinType.resolveConstructorFields(): List<Field> {
     val classSymbol = toRegularClassSymbol(session)
+    if (classSymbol?.moduleData is FirBinaryDependenciesModuleData) return emptyList()
     val primaryConstructor = classSymbol?.constructors(session)?.firstOrNull()
     return primaryConstructor?.valueParameterSymbols?.map { parameter ->
         Field(
@@ -160,6 +162,7 @@ private fun ConeKotlinType.resolveConstructorFields(): List<Field> {
 context(session: FirSession)
 private fun ConeKotlinType.resolvePropertyFields(): List<Field> {
     val classSymbol = toRegularClassSymbol(session)
+    if (classSymbol?.moduleData is FirBinaryDependenciesModuleData) return emptyList()
     return classSymbol?.declaredProperties(session)
         .orEmpty()
         .map { property ->

--- a/test-integration/src/test/kotlin/community/flock/kmapper/KMapperTest.kt
+++ b/test-integration/src/test/kotlin/community/flock/kmapper/KMapperTest.kt
@@ -1106,6 +1106,37 @@ class KMapperTest {
                 assertTrue(
                     output.contains("Missing mapping for: id"),
                     "Expected Missing mapping for: id"
+
+                )
+            }
+    }
+
+    @Test
+    fun shouldCompile_jdkTypes() {
+        IntegrationTest(options)
+            .file("App.kt") {
+                $$"""
+                |package sample
+                |
+                |import community.flock.kmapper.mapper
+                |import java.util.UUID
+                |import java.time.Instant
+                |
+                |data class EntityWithJdkTypes(val id: UUID, val name: String, val createdAt: Instant)
+                |data class DomainWithJdkTypes(val id: UUID, val name: String, val createdAt: Instant)
+                |
+                |fun main() {
+                |  val entity = EntityWithJdkTypes(id = UUID.randomUUID(), name = "test", createdAt = Instant.now())
+                |  val domain: DomainWithJdkTypes = entity.mapper()
+                |  println(domain)
+                |}
+                |
+                """.trimMargin()
+            }
+            .compileSuccess { output ->
+                assertTrue(
+                    output.contains("DomainWithJdkTypes("),
+                    "Expected DomainWithJdkTypes in output"
                 )
             }
     }


### PR DESCRIPTION
## Summary
- Skip field resolution when a class symbol originates from binary dependencies (`FirBinaryDependenciesModuleData`), preventing failures when mapping data classes that contain JDK types like `UUID` and `Instant`
- Applies the guard in both `resolveConstructorFields()` and `resolvePropertyFields()` in `KMapperFirMappingChecker` and `KmapperFirLogic`
- Adds integration test verifying compilation succeeds for data classes with JDK types

## Test plan
- [ ] Verify new `shouldCompile_jdkTypes` test passes
- [ ] Verify existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)