### PR TITLE
chore: bump Kotlin from 2.3.10 to 2.3.20

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "2.3.10"
+    kotlin("jvm") version "2.3.20"
     id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
     id("org.jetbrains.dokka") version "2.0.0" apply false
 }

--- a/compiler-plugin/build.gradle.kts
+++ b/compiler-plugin/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "2.3.10"
+    kotlin("jvm") version "2.3.20"
     id("maven-publish")
     id("org.jetbrains.dokka")
     id("com.gradleup.kctf").version("2.3.10-0.0.2-SNAPSHOT-a524b7d38d0ad625c3b891df859cc0be4b9c339b")

--- a/compiler-runtime/build.gradle.kts
+++ b/compiler-runtime/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    kotlin("jvm") version "2.3.10"
+    kotlin("jvm") version "2.3.20"
     id("maven-publish")
     id("org.jetbrains.dokka")
     signing

--- a/test-integration/build.gradle.kts
+++ b/test-integration/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "2.3.10"
+    kotlin("jvm") version "2.3.20"
 }
 
 group = rootProject.group
@@ -10,7 +10,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.2")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.2")
     implementation(gradleTestKit())
-    implementation("org.jetbrains.kotlin:kotlin-compiler-embeddable:2.3.10")
+    implementation("org.jetbrains.kotlin:kotlin-compiler-embeddable:2.3.20")
 }
 
 kotlin {


### PR DESCRIPTION
## Summary
- Bumps Kotlin from 2.3.10 to 2.3.20 across all modules
- Fixes `NoSuchMethodError` when the KMapper compiler plugin runs inside the Kotlin 2.3.20 compiler

## Root cause
Kotlin 2.3.20 removed deprecated `context(SessionHolder)` overloads of `toRegularClassSymbol` (and other methods) from `ToSymbolUtils.kt`. When KMapper 0.0.12 (compiled against 2.3.10) runs inside the 2.3.20 compiler, the bytecode references these removed methods, causing a runtime `NoSuchMethodError` in `KMapperFirMappingChecker.check`.

The non-deprecated `fun ConeKotlinType.toRegularClassSymbol(session: FirSession)` overload still exists — no source changes needed, just a recompile against 2.3.20.

## Test plan
- [ ] CI passes (compiler-plugin compiles against Kotlin 2.3.20)
- [ ] Integration tests pass
- [ ] Verify aigentic-platform builds with new KMapper + Kotlin 2.3.20