### PR TITLE
fix: allow enum auto-mapping when source is a strict subset of target

### DIFF
--- a/compiler-plugin/src/main/kotlin/community/flock/kmapper/compiler/fir/KMapperFirMappingChecker.kt
+++ b/compiler-plugin/src/main/kotlin/community/flock/kmapper/compiler/fir/KMapperFirMappingChecker.kt
@@ -70,7 +70,7 @@ class KMapperFirMappingChecker(val collector: MessageCollector, private val sess
             if (fromEnum != null && toEnum != null) {
                 val fromEntries = fromEnum.enumEntryNames().toSet()
                 val toEntries = toEnum.enumEntryNames().toSet()
-                if (fromEntries == toEntries) return
+                if (toEntries.containsAll(fromEntries)) return
             }
         }
 

--- a/compiler-plugin/src/main/kotlin/community/flock/kmapper/compiler/fir/KmapperFirLogic.kt
+++ b/compiler-plugin/src/main/kotlin/community/flock/kmapper/compiler/fir/KmapperFirLogic.kt
@@ -101,7 +101,7 @@ private fun enumsEqual(to: Field, from: Field): Boolean {
         to.type.toRegularClassSymbol(session)?.takeIf { it.isEnumClass }?.enumEntryNames()?.toSet() ?: return false
     val fromEntries = from.type.toRegularClassSymbol(session)?.takeIf { it.isEnumClass }?.enumEntryNames()?.toSet()
         ?: return false
-    return toEntries == fromEntries
+    return toEntries.containsAll(fromEntries)
 }
 
 context(session: FirSession, collector: MessageCollector)

--- a/test-integration/src/test/kotlin/community/flock/kmapper/EnumMappingTest.kt
+++ b/test-integration/src/test/kotlin/community/flock/kmapper/EnumMappingTest.kt
@@ -43,7 +43,7 @@ class EnumMappingTest {
     }
 
     @Test
-    fun shouldFail_notEqualEnums() {
+    fun shouldCompile_sourceSubsetOfTarget() {
         IntegrationTest(options)
             .file("App.kt") {
                 $$"""
@@ -51,11 +51,42 @@ class EnumMappingTest {
                 |
                 |import community.flock.kmapper.mapper
                 |
-                |enum class Gender { MALE, FEMALE }
+                |enum class Generation { GEN_Z, BOOMER }
+                |data class Person(val name: String, val age: Int, val generation: Generation)
+                |
+                |enum class GenerationDto { GEN_Z, MILLENNIALS, BOOMER }
+                |data class PersonDto(val name: String, val age: Int, val generation: GenerationDto)
+                |
+                |fun main() {
+                |  val person = Person("John", 30, Generation.GEN_Z)
+                |  val dto: PersonDto = person.mapper()
+                |  println(dto)
+                |}
+                |
+                """.trimMargin()
+            }
+            .compileSuccess { output ->
+                assertTrue(
+                    output.contains("PersonDto(name=John, age=30, generation=GEN_Z)"),
+                    "Expected PersonDto(name=John, age=30, generation=GEN_Z) in output"
+                )
+            }
+    }
+
+    @Test
+    fun shouldFail_sourceSupersetOfTarget() {
+        IntegrationTest(options)
+            .file("App.kt") {
+                $$"""
+                |package sample
+                |
+                |import community.flock.kmapper.mapper
+                |
+                |enum class Gender { MALE, FEMALE, OTHER }
                 |data class Address(val street: String, val city: String)
                 |data class Person(val name: String, val gender: Gender, val address: Address)
                 |
-                |enum class GenderDto { FEMALE, MALE, X }
+                |enum class GenderDto { FEMALE, MALE }
                 |data class AddressDto(val street: String, val city: String)
                 |data class PersonDto(val name: String, val gender: GenderDto, val address: AddressDto)
                 |


### PR DESCRIPTION
## Summary
- Relax symmetric enum auto-mapping so a source enum whose entries are a strict subset of the target is accepted — every source value still has an unambiguous name match, and target-only entries are simply unreachable.
- Swap set equality for `toEntries.containsAll(fromEntries)` in both `KMapperFirMappingChecker` (direct enum-to-enum early return) and `KmapperFirLogic.enumsEqual` (nested enum field check).
- No IR changes: the existing `Enum.valueOf(source.name)` emission already handles subset mapping correctly at runtime.

## Test plan
- [x] New integration test `EnumMappingTest.shouldCompile_sourceSubsetOfTarget` covers the issue's reproducer (`Generation { GEN_Z, BOOMER }` → `GenerationDto { GEN_Z, MILLENNIALS, BOOMER }`) and asserts the expected runtime output.
- [x] Renamed `shouldFail_notEqualEnums` → `shouldFail_sourceSupersetOfTarget` and flipped the enums so the failing direction (source has entries the target lacks) still produces `Missing mapping for: gender`.
- [x] `./gradlew :test-integration:test` passes end-to-end — no regressions in other enum / nested / label-property / collection scenarios.

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)